### PR TITLE
Remove mno-outlin-atomics for Rust

### DIFF
--- a/rust/rust-values.mk
+++ b/rust/rust-values.mk
@@ -54,6 +54,6 @@ ifeq ($(ARCH),arm)
   endif
 endif
 
-ifeq ($(ARCH),aarch64)
-    RUST_CFLAGS:=-mno-outline-atomics
-endif
+#ifeq ($(ARCH),aarch64)
+#    RUST_CFLAGS:=-mno-outline-atomics
+#endif


### PR DESCRIPTION
Thanks for your contribution to OpenMPTCProuter!

You need to follow contributing rules.

Please remove this message before posting the pull request.
1