### PR TITLE
Remove auto disable of ModemManager if not used because modems are no…

### DIFF
--- a/mptcp/files/usr/share/omr/post-tracking.d/010-services
+++ b/mptcp/files/usr/share/omr/post-tracking.d/010-services
@@ -101,10 +101,10 @@ if [ -z "$(pgrep ModemManager)" ] && [ -f /etc/init.d/modemmanager ] && [ -n "$(
 	_log "Can't find ModemManager, restart it..."
 	/etc/init.d/modemmanager restart 2>&1 >/dev/null
 	sleep 5
-elif [ -n "$(pgrep ModemManager)" ] && [ -f /etc/init.d/modemmanager ] && [ -z "$(uci -q show network | grep modemmanager)" ]; then
-	_log "ModemManager not used, stop it..."
-	/etc/init.d/modemmanager stop 2>&1 >/dev/null
-	sleep 5
+#elif [ -n "$(pgrep ModemManager)" ] && [ -f /etc/init.d/modemmanager ] && [ -z "$(uci -q show network | grep modemmanager)" ]; then
+#	_log "ModemManager not used, stop it..."
+#	/etc/init.d/modemmanager stop 2>&1 >/dev/null
+#	sleep 5
 fi
 
 if [ "$(uci -q get v2ray.main.enabled)" = "1" ] && [ -f /etc/init.d/v2ray ] && [ "$(pgrep -f omr-tracker-v2ray)" = "" ] && [ "$(pgrep -f '/etc/init.d/omr-tracker')" = "" ]; then


### PR DESCRIPTION
…t visibles in interfaces directly and it's confusing, another solution must be found

Thanks for your contribution to OpenMPTCProuter!

You need to follow contributing rules.

Please remove this message before posting the pull request.
1